### PR TITLE
Minor Windows build changes

### DIFF
--- a/.github/workflows/github_actions_build.yml
+++ b/.github/workflows/github_actions_build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  buildUbuntu:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@master
+    - name: make
+      run: make
+      
+  buildOSX:
+    runs-on: macOS-latest
+    
+    steps:
+    - uses: actions/checkout@master
+    - name: make
+      run: make CLANG=Y
+      
+  buildWindows:
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@master
+    - name: make
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        nmake -f lunar.mak

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ include files in `/usr/local/include`.  (You will probably have to make that
 `sudo make install`.)  For BSD,  and probably OS/X,  run `gmake CLANG=Y`
 (GNU make,  with the clang compiler),  then `sudo gmake install`.
 
-On Windows,  run `nmake -f lunardll.mak` with MSVC++.  Optionally,  add
-`-BITS_32=Y` for 32-bit code.
+On Windows,  run `nmake -f lunar.mak` with MSVC++.  Optionally,  add
+`BITS_32=Y` for 32-bit code.

--- a/lunar.mak
+++ b/lunar.mak
@@ -27,11 +27,11 @@ LIB_OBJS= ades2mpc.obj alt_az.obj astfuncs.obj \
 LINK=link /nologo
 
 !ifdef BITS_32
-BASE_FLAGS=-nologo -W3 -Ox -MT
+BASE_FLAGS=-nologo -W3 -O2 -MT -D_CRT_SECURE_NO_WARNINGS
 LIBNAME=lunar
-RM=rm
+RM=del
 !else
-BASE_FLAGS=-nologo -W3 -Ox -D_CRT_SECURE_NO_WARNINGS
+BASE_FLAGS=-nologo -W3 -O2 -MT -D_CRT_SECURE_NO_WARNINGS
 LIBNAME=lunar64
 RM=del
 !endif

--- a/lunar.mak
+++ b/lunar.mak
@@ -143,7 +143,7 @@ ssattest.exe: ssattest.obj $(LIBNAME).lib
    $(LINK)    ssattest.obj $(LIBNAME).lib
 
 ssats.obj: ssats.cpp
-   cl -c $(COMMON_FLAGS) -Od ssats.cpp
+   cl -c $(COMMON_FLAGS) ssats.cpp
 
 tables.exe: tables.obj riseset3.obj $(LIBNAME).lib
    $(LINK)  tables.obj riseset3.obj $(LIBNAME).lib


### PR DESCRIPTION
Couple of small changes that I believe improve the Windows build. Note: the s/Ox/O2 change is from: https://twitter.com/lefticus/status/1040287121058127872

Also I believe to build x64/Win32 you need to run the appropriate vcvarsall.bat x64 / vcvarsall.bat x86 rather than just pass BITS_32=Y

Windows builds pretty cleanly with -D_CRT_SECURE_NO_WARNINGS but does warn on the following:

date.cpp(760): warning C4244: '=': conversion from '__int64' to 'long', possible loss of data
date.cpp(762): warning C4244: '=': conversion from '__int64' to 'long', possible loss of data

I believe as 1970768981732L is long long which is bigger than long (on Windows)