### PR TITLE
Update buildWindows to use shell: cmd

### DIFF
--- a/.github/workflows/github_actions_build.yml
+++ b/.github/workflows/github_actions_build.yml
@@ -28,3 +28,4 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
         nmake -f lunar.mak
+      shell: cmd


### PR DESCRIPTION
Fix the Windows build as per:

https://github.blog/changelog/2019-10-17-github-actions-default-shell-on-windows-runners-is-changing-to-powershell/

